### PR TITLE
Slightly improve homoplygh-function.py

### DIFF
--- a/Python/homoglyph-function.py
+++ b/Python/homoglyph-function.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 def sayHello():
-    print("Hello, World!\n");
+    print("Hello, World!")
 
 def sayНello():
-    print("Goodbye, World!\n");
+    print("Goodbye, World!")
 
-sayНello();
+sayНello()


### PR DESCRIPTION
Python doesn't use semicolons, and its `print()` already outputs a newline. Removing these extras clarifies the example a bit 🙂