### PR TITLE
appropriate demonstration

### DIFF
--- a/Python/homoglyph-function.py
+++ b/Python/homoglyph-function.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-def sayHello():
-    print("Hello, World!")
-
 def sayНello():
     print("Goodbye, World!")
+
+def sayHello():
+    print("Hello, World!")
 
 sayНello()


### PR DESCRIPTION
As python does not support function overloading and functions with the same name would make the later one override the prior one, moving the `say\xd0\x9ello` function ahead of the `sayHello` function would be much more appropriate for demonstration.