### PR TITLE
Add Ruby As a Vulnerable Language

### DIFF
--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -1,0 +1,29 @@
+# Ruby
+
+## Commenting-Out
+
+Because of the lack of comments with a closing token this doesn't work
+the same way as other languages. For more info see:
+
+https://github.com/nickboucher/trojan-source/issues/8#issuecomment-962468707
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Early Return
+
+Also dues not work the same as other languages because of lack of closing token
+on comments. See same link as above.
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Homoglyph Function
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Invisible Function
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Stretched String
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -11,7 +11,7 @@ https://github.com/nickboucher/trojan-source/issues/8#issuecomment-962468707
 
 ## Early Return
 
-Also dues not work the same as other languages because of lack of closing token
+Also does not work the same as other languages because of lack of closing token
 on comments. See same link as above.
 
 - Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
@@ -30,8 +30,7 @@ on comments. See same link as above.
 
 # Variations
 
-Some variations that may or may not be applicable in other languages. For
-more info see:
+Variations that may or may not be applicable in other languages. More info at:
 
 https://github.com/nickboucher/trojan-source/issues/9
 

--- a/Ruby/README.md
+++ b/Ruby/README.md
@@ -27,3 +27,22 @@ on comments. See same link as above.
 ## Stretched String
 
 - Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+# Variations
+
+Some variations that may or may not be applicable in other languages. For
+more info see:
+
+https://github.com/nickboucher/trojan-source/issues/9
+
+## Stretched Regexp
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Stretched String List
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
+
+## Stretched Variable
+
+- Confirmed working on ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]

--- a/Ruby/commenting-out.rb
+++ b/Ruby/commenting-out.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+is_admin = false
+⁧⁦ = true; #⁩⁦if is_admin       # Begin block if is_admin⁩⁩
+  puts 'You are an admin.'
+⁧⁦ = true;   #⁩⁦end               # End block if is_admin ⁩⁩

--- a/Ruby/early-return.rb
+++ b/Ruby/early-return.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+$bank = { 'alice' => 100 }
+
+def subtract_funds account, amount
+  ⁧⁦ = amount and return # ⁩⁦# Subtract from acct the value⁩⁩
+  $bank[account] -= amount
+end
+
+subtract_funds 'alice', 50
+puts $bank.inspect

--- a/Ruby/homoglyph-function.rb
+++ b/Ruby/homoglyph-function.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+def sayНello
+  puts "Goodbye, World!"
+end
+
+def sayHello
+  puts "Hello, World!"
+end
+
+sayНello

--- a/Ruby/invisible-functions.rb
+++ b/Ruby/invisible-functions.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+def is_admin
+  false
+end
+
+def is_​admin
+  true
+end
+
+if is_​admin
+  puts "You are an admin."
+end

--- a/Ruby/stretched-regex.rb
+++ b/Ruby/stretched-regex.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+$roles = 'user,manager'
+def admin?
+  $roles =~ /admin⁧⁦|user/ #⁩⁦/ # Restrict from ⁩⁩
+end
+
+if admin?
+  puts 'You are an admin.'
+end

--- a/Ruby/stretched-string-list.rb
+++ b/Ruby/stretched-string-list.rb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+role = 'User'
+privileged = %w(Admin Manager⁧⁦ User) # ⁩⁦) # All roles (except  ⁩⁩
+if privileged.include? role
+  puts 'You are an admin.'
+end

--- a/Ruby/stretched-string.rb
+++ b/Ruby/stretched-string.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+access_level = "user"
+if access_level != "user‮⁦" # Check if admin⁩⁦
+  puts "You are an admin."
+end

--- a/Ruby/stretched-variable.rb
+++ b/Ruby/stretched-variable.rb
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+role⁧⁦= 'Admin' #⁩⁦ # Condition will ensure 'User' !⁩⁦ = 'User'⁩⁩
+if role⁧⁦ == 'Admin'
+  puts 'You are an admin.'
+end


### PR DESCRIPTION
Per the feedback at https://github.com/nickboucher/trojan-source/issues/9#issuecomment-962087735 that you are open to have Ruby examples:

a7f0aee adds the same examples that are in the other languages. Homoglyph method names and invisible functions are sort of "yawn" with Ruby given it's support for monkey-patching. It would be easier to just define the method again with the same name. But included them for completeness. Tried to follow the style of the other languages.

49d8720 adds some additional variations that are probably not applicable to every language but may be applicable to some other languages.

I did reach out to the Ruby security team to see if they want to address. They responded with "at the moment, our opinion is that the interpreter is not the right place for a fix".