### PR TITLE
Add PHP as a vulnerable language

### DIFF
--- a/PHP/README.md
+++ b/PHP/README.md
@@ -1,0 +1,17 @@
+# PHP
+
+## Commenting-Out
+
+- Confirmed working PHP 8.0.13 and 8.1.0-RC6 (Ubuntu)
+
+## Stretched String
+
+- Confirmed working PHP 8.0.13 and 8.1.0-RC6 (Ubuntu)
+
+## Invisible Functions
+
+- Confirmed working PHP 8.0.13 and 8.1.0-RC6 (Ubuntu)
+
+## Homoglyph Function
+
+- Confirmed working PHP 8.0.13 and 8.1.0-RC6 (Ubuntu)

--- a/PHP/commenting-out.php
+++ b/PHP/commenting-out.php
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+$isAdmin = false;
+/*‮ } ⁦if ($isAdmin)⁩ ⁦ begin admins only */
+    echo "You are an admin.";
+/* end admins only ‮ { ⁦*/

--- a/PHP/homoglyph-function.php
+++ b/PHP/homoglyph-function.php
@@ -1,0 +1,12 @@
+#!/usr/bin/env php
+<?php
+
+function sayHello() {
+    echo "Hello, World!\n";
+}
+
+function sayНello() {
+    echo "Goodbye, World!\n";
+}
+
+sayНello();

--- a/PHP/invisible-function.php
+++ b/PHP/invisible-function.php
@@ -1,0 +1,16 @@
+#!/usr/bin/env php
+<?php
+
+function isAdmin() {
+    return false;
+}
+
+function is​Admin() {
+    return true;
+}
+
+if (is​Admin()) {
+    echo "You are an admin\n";
+} else {
+    echo "You are NOT an admin.\n";
+}

--- a/PHP/stretched-string.php
+++ b/PHP/stretched-string.php
@@ -1,0 +1,6 @@
+#!/usr/bin/env php
+<?php
+$accessLevel = "user";
+if ($accessLevel != "user‮ ⁦// Check if admin⁩ ⁦") {
+    echo "You are an admin.";
+}


### PR DESCRIPTION
Based off the JS tests as the languages are very similar. This has also been reported as a security issue to the PHP project (security reports are private so I can't link to it).