### PR TITLE
Add POC for commenting out multiple lines in C

### DIFF
--- a/C/commenting-out-multiple-lines.c
+++ b/C/commenting-out-multiple-lines.c
@@ -1,0 +1,10 @@
+#include<stdio.h>
+
+int main() {
+	printf("Hi\n");
+	/* Hello ‮ ⁦printf("Hello World\n");⁩ ⁦*​/⁩
+	printf("Hello\n");
+	printf("Hello again\n");
+	/*  Bye  ‮ ⁦printf("Bye World\n");⁩ ⁦*/
+ 	return 0;
+ }


### PR DESCRIPTION
By using the Zero Width Space character between */ in line 5, we can comment lines beyond the current line with Bidi characters.

Interestingly, Github UI does not show the zero width space character in its warning.